### PR TITLE
Support PKZIP files with extraneous null padding between blocks

### DIFF
--- a/lib/unzip-stream.js
+++ b/lib/unzip-stream.js
@@ -82,6 +82,13 @@ UnzipStream.prototype.processDataChunk = function (chunk) {
 
     switch (this.state) {
         case states.START:
+            while (chunk[0] === 0x00 && chunk.length) {
+                chunk = chunk.slice(1, chunk.length);
+                chunkLength = chunk.length;
+                if ( chunkLength < requiredLength ) {
+                    return 0;
+                }
+            }
             switch (chunk.readUInt32LE(0)) {
                 case LOCAL_FILE_HEADER_SIG:
                     this.state = states.LOCAL_FILE_HEADER;

--- a/lib/unzip-stream.js
+++ b/lib/unzip-stream.js
@@ -83,7 +83,8 @@ UnzipStream.prototype.processDataChunk = function (chunk) {
     switch (this.state) {
         case states.START:
             while (chunk[0] === 0x00 && chunk.length) {
-                chunk = chunk.slice(1, chunk.length);
+                this.data = this.data.slice(1, this.data.length);
+                chunk = this.data;
                 chunkLength = chunk.length;
                 if ( chunkLength < requiredLength ) {
                     return 0;


### PR DESCRIPTION
Fixes #4 

Very simple approach. Before checking for the next block signature, advance one byte while the next byte is `NULL`.