### PR TITLE
Emit close event on next tick when unzip stream ends

### DIFF
--- a/lib/parser-stream.js
+++ b/lib/parser-stream.js
@@ -31,7 +31,7 @@ ParserStream.prototype._transform = function (chunk, encoding, cb) {
 
 ParserStream.prototype._flush = function (cb) {
     this.unzipStream.end(() => {
-        this.emit('close'); // compatibility with node-unzip
+        process.nextTick(() => this.emit('close')); // compatibility with node-unzip
         cb();
     });
 }


### PR DESCRIPTION
Apologies for the lack of test here. I'll explain how I uncovered this and you can decide whether you think a test is essential here and/or whether you'd like to merge this.

By emitting a close event before the stream has necessarily ended, this library triggers end-of-streams premature close error:

https://github.com/mafintosh/end-of-stream/blob/master/index.js#L43-L44

This sort of error would also happen if a server connection was aborted while a request was in flight. Depending on what's extracted and how big the buffer in the stream pipeline grows, the close event can be emitted before the stream ends. 

Emitting the close event on next tick resolved the error for me.