### PR TITLE
enable unzip non-utf-8 file

### DIFF
--- a/lib/unzip-stream.js
+++ b/lib/unzip-stream.js
@@ -5,6 +5,9 @@ var zlib = require('zlib');
 var MatcherStream = require('./matcher-stream');
 var Entry = require('./entry');
 
+var jschardet = require('jschardet');
+var Iconv = require('iconv').Iconv;
+
 const states = {
     START: 0,
     LOCAL_FILE_HEADER: 1,
@@ -107,7 +110,10 @@ UnzipStream.prototype.processDataChunk = function (chunk) {
 
         case states.LOCAL_FILE_HEADER_SUFFIX:
             var entry = new Entry();
-            entry.path = chunk.slice(0, this.parsedEntity.fileNameLength).toString();
+
+            var name = chunk.slice(0, this.parsedEntity.fileNameLength);
+            var enc = jschardet.detect(name).encoding;
+            entry.path = new Iconv(enc, 'utf-8//IGNORE').convert(name).toString();
             this.parsedEntity.extra = this._readExtraFields(chunk.slice(this.parsedEntity.fileNameLength, this.parsedEntity.fileNameLength + this.parsedEntity.extraFieldLength));
             this._prepareOutStream(this.parsedEntity, entry);
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "license": "MIT",
   "dependencies": {
     "binary": "^0.3.0",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "iconv": "^2.2.3",
+    "jschardet": "^1.4.2"
   },
   "devDependencies": {
     "tap": ">= 0.3.0 < 1",


### PR DESCRIPTION
I could not unzip the file containing shift-jis. So, I was very sad.
And made it possible.