### PR TITLE
ParserStream: Fire `close` event only once on `UnzipStream`'s `end` e…

### DIFF
--- a/lib/parser-stream.js
+++ b/lib/parser-stream.js
@@ -20,6 +20,9 @@ function ParserStream(opts) {
     this.unzipStream.on('error', function(error) {
         self.emit('error', error);
     });
+    this.unzipStream.on('end', function() {
+        process.nextTick(function() { self.emit('close'); });
+    });
 }
 
 util.inherits(ParserStream, Transform);
@@ -31,7 +34,6 @@ ParserStream.prototype._transform = function (chunk, encoding, cb) {
 ParserStream.prototype._flush = function (cb) {
     var self = this;
     this.unzipStream.end(function() {
-        process.nextTick(function() { self.emit('close'); });
         cb();
     });
 }


### PR DESCRIPTION
Fix for #23.