### PR TITLE
Prevent test data from being published

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,6 @@
 /.idea
 /node_modules
 /test
-/testData
+/testData*
+*.zip
+.travis.yml


### PR DESCRIPTION
Guess those test files are created before publishing. Also .travis.yml shoulld probably not be published.

This is the content of the installed package version 0.3.1:

![Screenshot 2023-03-09 at 16 42 34](https://user-images.githubusercontent.com/6443408/224077377-6399750c-47b2-4d29-9db8-977dcd8fc274.png)
