### PR TITLE
Update Buffer indication

### DIFF
--- a/lib/matcher-stream.js
+++ b/lib/matcher-stream.js
@@ -14,7 +14,7 @@ function MatcherStream(patternDesc, matchFn) {
     this.requiredLength = this.pattern.length;
     if (patternDesc.requiredExtraSize) this.requiredLength += patternDesc.requiredExtraSize;
 
-    this.data = new Buffer('');
+    this.data = Buffer.from('');
     this.bytesSoFar = 0;
 
     this.matchFn = matchFn;
@@ -57,7 +57,7 @@ MatcherStream.prototype.checkDataChunk = function (ignoreMatchZero) {
 
     var finished = this.matchFn ? this.matchFn(this.data, this.bytesSoFar) : true;
     if (finished) {
-        this.data = new Buffer('');
+        this.data = Buffer.from('');
         return;
     }
 

--- a/lib/unzip-stream.js
+++ b/lib/unzip-stream.js
@@ -44,7 +44,7 @@ function UnzipStream(options) {
     stream.Transform.call(this);
 
     this.options = options || {};
-    this.data = new Buffer('');
+    this.data = Buffer.from('');
     this.state = states.STREAM_START;
     this.skippedBytes = 0;
     this.parsedEntity = null;
@@ -306,7 +306,7 @@ UnzipStream.prototype._prepareOutStream = function (vars, entry) {
     };
 
     if (!fileSizeKnown) {
-        var pattern = new Buffer(4);
+        var pattern = Buffer.alloc(4);
         pattern.writeUInt32LE(SIG_DATA_DESCRIPTOR, 0);
         var zip64Mode = vars.extra.zip64Mode;
         var extraSize = zip64Mode ? 20 : 12;


### PR DESCRIPTION
I prepare a small update to eliminate  `Buffer` constructor has been deprecated due to security and usability issues. 

> DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

Related to: https://github.com/mhr3/unzip-stream/issues/38