### PR TITLE
Replaced Buffer constructor with Buffer.from and Buffer.alloc

### DIFF
--- a/lib/matcher-stream.js
+++ b/lib/matcher-stream.js
@@ -14,7 +14,7 @@ function MatcherStream(patternDesc, matchFn) {
     this.requiredLength = this.pattern.length;
     if (patternDesc.requiredExtraSize) this.requiredLength += patternDesc.requiredExtraSize;
 
-    this.data = new Buffer('');
+    this.data = Buffer.from('');
     this.bytesSoFar = 0;
 
     this.matchFn = matchFn;
@@ -57,7 +57,7 @@ MatcherStream.prototype.checkDataChunk = function (ignoreMatchZero) {
 
     var finished = this.matchFn ? this.matchFn(this.data, this.bytesSoFar) : true;
     if (finished) {
-        this.data = new Buffer('');
+        this.data = Buffer.from('');
         return;
     }
 

--- a/lib/unzip-stream.js
+++ b/lib/unzip-stream.js
@@ -44,7 +44,7 @@ function UnzipStream(options) {
     stream.Transform.call(this);
 
     this.options = options || {};
-    this.data = new Buffer('');
+    this.data = Buffer.from('');
     this.state = states.STREAM_START;
     this.skippedBytes = 0;
     this.parsedEntity = null;
@@ -306,7 +306,7 @@ UnzipStream.prototype._prepareOutStream = function (vars, entry) {
     };
 
     if (!fileSizeKnown) {
-        var pattern = new Buffer(4);
+        var pattern = Buffer.alloc(4);
         pattern.writeUInt32LE(SIG_DATA_DESCRIPTOR, 0);
         var zip64Mode = vars.extra.zip64Mode;
         var extraSize = zip64Mode ? 20 : 12;
@@ -662,7 +662,7 @@ UnzipStream.prototype._parseOrOutput = function (encoding, cb) {
                 this.data = this.data.slice(remaining);
             } else {
                 packet = this.data;
-                this.data = new Buffer('');
+                this.data = Buffer.from('');
             }
 
             this.outStreamInfo.written += packet.length;
@@ -675,7 +675,7 @@ UnzipStream.prototype._parseOrOutput = function (encoding, cb) {
             }
         } else {
             var packet = this.data;
-            this.data = new Buffer('');
+            this.data = Buffer.from('');
 
             this.outStreamInfo.written += packet.length;
             var outputStream = this.outStreamInfo.stream;


### PR DESCRIPTION
Replaced `Buffer` constructor with `Buffer.from()` and `Buffer.alloc()` where appropriate. 

unzip-stream no longer works with the latest Electron (31.2.1), so this needs to be updated. 

Related to issue #38 