### PR TITLE
chore: swap travis for gha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,28 @@ on:
   pull_request:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         node-version: [24.x, 22.x, 20.x, 18.x, 16.x, 12.x, 10.x, 8.x, 6.x, 4.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # 6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [24.x, 22.x, 20.x, 18.x, 16.x, 12.x, 10.x, 8.x, 6.x, 4.x]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   test:
+    name: Test on Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,4 @@
 /test
 /testData*
 *.zip
-.travis.yml
+/.github

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - "node"
-  - "12"
-  - "10"
-  - "8"
-  - "6"
-  - "4"
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# unzip-stream [![Build Status](https://travis-ci.org/mhr3/unzip-stream.svg?branch=master)](https://travis-ci.org/mhr3/unzip-stream)
+# unzip-stream ![Build Status](https://github.com/mhr3/unzip-stream/actions/workflows/ci.yml/badge.svg?branch=master)
 
 Streaming cross-platform unzip tool written in node.js.
 


### PR DESCRIPTION
Uses the travis + extends to a range of supported and unsupported versions of node.

(want to see the #55 in there but should probably slap some ci for confidence in changes.)